### PR TITLE
PA-4794 & PA-4798 Sarif Destination and outPutFormat

### DIFF
--- a/main.py
+++ b/main.py
@@ -812,7 +812,7 @@ class SOOSDASTAnalysis:
             "--outputFormat",
             help="Output format for vulnerabilities: only the value sarif is available at the moment. ",
             type=str,
-            default=False,
+            default=None,
             required=False
         )
 


### PR DESCRIPTION
### Changes:
  - Modification to use a different project name than repo-owner/repo-name when trying to upload sarif to github.
  - changed sarif param to outputFormat, if sarif then the report will be generated and it will be printed in the console.

**Ticket:** https://soos.atlassian.net/browse/PA-4794
**Ticket:** https://soos.atlassian.net/browse/PA-4798
