### PR TITLE
PA-6734 Include req/response headers by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The basic command to run a baseline scan would look like:
 | --buildVersion | None | Version of application build artifacts |
 | --buildURI | None | URI to CI build info |
 | --operatingEnvironment | None | Set Operating environment for information porpuses only |
-| --reportRequestHeaders | False | Include request/response headers data in report |
+| --reportRequestHeaders | True | Include request/response headers data in report |
 | --outputFormat | None | Output format for vulnerabilities: only the value sarif is available at the moment |
 | --gpat | None | GitHub Personal Authorization Token |
 | --bearerToken | None | Bearer token to authenticate |

--- a/main.py
+++ b/main.py
@@ -843,7 +843,7 @@ class SOOSDASTAnalysis:
             "--reportRequestHeaders",
             help="Include request/response headers data in report",
             type=bool,
-            default=False,
+            default=True,
             required=False
         )
 


### PR DESCRIPTION
### Changes:
  - Enabled req-response headers by default

**Ticket:** https://soos.atlassian.net/browse/PA-6734

<!---
If you've edited any of the arguments for this package:

1. Run this script with the --helpFormatted argument (ex. soos-dast --helpFormatted)
2. Copy the result and paste it in the README under '### Script Arguments'
3. Make sure your terminal didn't wrap any lines, confirm the table looks correct
-->
