### PR TITLE
Move fullscanMinutes back to old default

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The basic command to run a baseline scan would look like:
 | `--contextFile` | None | Context file which will be loaded prior to scanning the target |
 | `--debug` | False | Enable debug logging for ZAP. |
 | `--disableRules` | None | Comma separated list of ZAP rules IDs to disable. List for reference https://www.zaproxy.org/docs/alerts/ |
-| `--fullScanMinutes` | None | Number of minutes for the spider to run |
+| `--fullScanMinutes` | 1 | Number of minutes for the spider to run |
 | `--help`, `-h` | ==SUPPRESS== | show this help message and exit |
 | `--integrationName` | None | Integration Name - Intended for internal use only. |
 | `--integrationType` | None | Integration Type - Intended for internal use only. |

--- a/src/index.ts
+++ b/src/index.ts
@@ -244,7 +244,7 @@ class SOOSDASTAnalysis {
 
     parser.add_argument("--fullScanMinutes", {
       help: "Number of minutes for the spider to run.",
-      default: 120,
+      default: 1,
       required: false,
     });
 


### PR DESCRIPTION
### Changes:
  - Description of the change

**Ticket:** https://soos.atlassian.net/browse/PA-0000

<!---
If you've edited any of the arguments for this package:

1. Run this script with the --helpFormatted argument (ex. soos-dast --helpFormatted)
2. Copy the result and paste it in the README under '### Script Arguments'
3. Make sure your terminal didn't wrap any lines, confirm the table looks correct
-->
