### PR TITLE
PA-12765 Add excludeUrlsFile param

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The basic command to run a baseline scan would look like:
 | `--commitHash` |  | The commit hash value from the SCM System |
 | `--contextFile` |  | Context file which will be loaded prior to scanning the target |
 | `--debug` |  | Enable debug logging for ZAP. |
-| `--excludeUrls` | | Comma separated list of regex Urls to exclude from the scan.`
+| `--excludeUrlsFile` | | Path to a file containing regex URLs to exclude, one per line. eg `--excludeUrlsFile=exclude_urls.txt`
 | `--disableRules` |  | Comma separated list of ZAP rules IDs to disable. List for reference https://www.zaproxy.org/docs/alerts/ |
 | `--fullScanMinutes` |  | Number of minutes for the spider to run |
 | `--logLevel` |  | Minimum level to show logs: DEBUG INFO, WARN, FAIL, ERROR. |

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The basic command to run a baseline scan would look like:
 | `--commitHash` |  | The commit hash value from the SCM System |
 | `--contextFile` |  | Context file which will be loaded prior to scanning the target |
 | `--debug` |  | Enable debug logging for ZAP. |
+| `--excludeUrls` | | Comma separated list of regex Urls to exclude from the scan.`
 | `--disableRules` |  | Comma separated list of ZAP rules IDs to disable. List for reference https://www.zaproxy.org/docs/alerts/ |
 | `--fullScanMinutes` |  | Number of minutes for the spider to run |
 | `--logLevel` |  | Minimum level to show logs: DEBUG INFO, WARN, FAIL, ERROR. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "soos-dast",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "soos-dast",
-      "version": "2.0.20",
+      "version": "2.0.21",
       "license": "MIT",
       "dependencies": {
         "@soos-io/api-client": "0.2.35",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "soos-dast",
-  "version": "2.0.20",
+  "version": "2.0.21",
   "description": "SOOS DAST - The affordable no limit web vulnerability scanner",
   "main": "index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export interface SOOSDASTAnalysisArgs extends IBaseScanArguments {
   contextFile: string;
   debug: boolean;
   disableRules: string;
+  excludeUrls: string;
   fullScanMinutes: number;
   oauthParameters: string;
   oauthTokenUrl: string;
@@ -179,6 +180,12 @@ class SOOSDASTAnalysis {
 
     analysisArgumentParser.argumentParser.add_argument("--disableRules", {
       help: "Comma separated list of ZAP rules IDs to disable. List for reference https://www.zaproxy.org/docs/alerts/",
+      required: false,
+      nargs: "*",
+    });
+
+    analysisArgumentParser.argumentParser.add_argument("--excludeUrls", {
+      help: "Comma separated list of regex Urls to exclude from the scan.",
       required: false,
       nargs: "*",
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,7 @@ export interface SOOSDASTAnalysisArgs extends IBaseScanArguments {
   contextFile: string;
   debug: boolean;
   disableRules: string;
-  excludeUrls: string;
+  excludeUrlsFile: string;
   fullScanMinutes: number;
   oauthParameters: string;
   oauthTokenUrl: string;
@@ -184,10 +184,9 @@ class SOOSDASTAnalysis {
       nargs: "*",
     });
 
-    analysisArgumentParser.argumentParser.add_argument("--excludeUrls", {
-      help: "Comma separated list of regex Urls to exclude from the scan.",
+    analysisArgumentParser.argumentParser.add_argument("--excludeUrlsFile", {
+      help: "Path to a file containing regex URLs to exclude, one per line.",
       required: false,
-      nargs: "*",
     });
 
     analysisArgumentParser.argumentParser.add_argument("--fullScanMinutes", {

--- a/src/utilities/ZAPCommandGenerator.ts
+++ b/src/utilities/ZAPCommandGenerator.ts
@@ -55,6 +55,7 @@ export class ZAPCommandGenerator {
     this.addEnvironmentVariable("CUSTOM_COOKIES", this.config.requestCookies);
     this.addEnvironmentVariable("CUSTOM_HEADER", this.config.requestHeaders);
     this.addEnvironmentVariable("DISABLE_RULES", this.config.disableRules);
+    this.addEnvironmentVariable("EXCLUDE_URLS", this.config.excludeUrls);
     this.addEnvironmentVariable("OAUTH_PARAMETERS", this.config.oauthParameters);
     this.addEnvironmentVariable("OAUTH_TOKEN_URL", this.config.oauthTokenUrl);
     if (this.config.debug) this.addEnvironmentVariable("DEBUG_MODE", this.config.debug);

--- a/src/utilities/ZAPCommandGenerator.ts
+++ b/src/utilities/ZAPCommandGenerator.ts
@@ -55,7 +55,7 @@ export class ZAPCommandGenerator {
     this.addEnvironmentVariable("CUSTOM_COOKIES", this.config.requestCookies);
     this.addEnvironmentVariable("CUSTOM_HEADER", this.config.requestHeaders);
     this.addEnvironmentVariable("DISABLE_RULES", this.config.disableRules);
-    this.addEnvironmentVariable("EXCLUDE_URLS", this.config.excludeUrls);
+    this.addEnvironmentVariable("EXCLUDE_URLS_FILE", this.config.excludeUrlsFile);
     this.addEnvironmentVariable("OAUTH_PARAMETERS", this.config.oauthParameters);
     this.addEnvironmentVariable("OAUTH_TOKEN_URL", this.config.oauthTokenUrl);
     if (this.config.debug) this.addEnvironmentVariable("DEBUG_MODE", this.config.debug);

--- a/src/zap_hooks/helpers/configuration.py
+++ b/src/zap_hooks/helpers/configuration.py
@@ -37,6 +37,7 @@ class DASTConfig:
     oauth_parameters: Optional[str] = None
     disable_rules: Optional[str] = None
     debug_mode: Optional[bool] = False
+    exclude_urls: Optional[List[str]] = None
 
     def __init__(self):
         self.extra_zap_params = None
@@ -73,6 +74,7 @@ class DASTConfig:
             self.oauth_parameters = self._get_hook_param_list(os.environ.get('OAUTH_PARAMETERS')) or EMPTY_STRING
             self.disable_rules = self._get_hook_param_list(os.environ.get('DISABLE_RULES')) or None
             self.debug_mode = os.environ.get('DEBUG_MODE') or False
+            self.exclude_urls = self._get_hook_param_list(os.environ.get('EXCLUDE_URLS')) or list()
 
         except Exception as error:
             log(f"error in start_docker_zap: {traceback.print_exc()}", log_level=LogLevel.ERROR)

--- a/src/zap_hooks/helpers/configuration.py
+++ b/src/zap_hooks/helpers/configuration.py
@@ -37,7 +37,7 @@ class DASTConfig:
     oauth_parameters: Optional[str] = None
     disable_rules: Optional[str] = None
     debug_mode: Optional[bool] = False
-    exclude_urls: Optional[List[str]] = None
+    exclude_urls_file: Optional[str] = None
 
     def __init__(self):
         self.extra_zap_params = None
@@ -74,7 +74,7 @@ class DASTConfig:
             self.oauth_parameters = self._get_hook_param_list(os.environ.get('OAUTH_PARAMETERS')) or EMPTY_STRING
             self.disable_rules = self._get_hook_param_list(os.environ.get('DISABLE_RULES')) or None
             self.debug_mode = os.environ.get('DEBUG_MODE') or False
-            self.exclude_urls = self._get_hook_param_list(os.environ.get('EXCLUDE_URLS')) or list()
+            self.exclude_urls_file = os.environ.get('EXCLUDE_URLS_FILE') or None
 
         except Exception as error:
             log(f"error in start_docker_zap: {traceback.print_exc()}", log_level=LogLevel.ERROR)

--- a/src/zap_hooks/soos_zap_hook.py
+++ b/src/zap_hooks/soos_zap_hook.py
@@ -53,6 +53,10 @@ def zap_started(zap, target):
             serialize_and_save(zap.core, 'wrk/core_data_started.json')
             serialize_and_save(zap.pscan, 'wrk/pscan_data_started.json')
             serialize_and_save(zap.context, 'wrk/context_data_started.json')
+        if config.exclude_urls:
+            for url in config.exclude_urls:
+                log(f"Excluding url on spider: {url}")
+                zap.spider.exclude_from_scan(url)
     except Exception:
         exit_app(f"error in zap_started: {traceback.print_exc()}")
 

--- a/src/zap_hooks/soos_zap_hook.py
+++ b/src/zap_hooks/soos_zap_hook.py
@@ -53,10 +53,14 @@ def zap_started(zap, target):
             serialize_and_save(zap.core, 'wrk/core_data_started.json')
             serialize_and_save(zap.pscan, 'wrk/pscan_data_started.json')
             serialize_and_save(zap.context, 'wrk/context_data_started.json')
-        if config.exclude_urls:
-            for url in config.exclude_urls:
-                log(f"Excluding url on spider: {url}")
-                zap.spider.exclude_from_scan(url)
+        if config.exclude_urls_file:
+            exclude_urls_file_path = f"wrk/{config.exclude_urls_file}"
+            with open(exclude_urls_file_path) as f:
+                for line in f:
+                    url = line.strip()
+                    log(f"Excluding url on spider: {url}")
+                    zap.spider.exclude_from_scan(url)
+            
     except Exception:
         exit_app(f"error in zap_started: {traceback.print_exc()}")
 


### PR DESCRIPTION
### Changes:
 - Added excludeUrlsFile param
 
**Ticket:** https://soos.atlassian.net/browse/PA-12765

Usage will be like this, where the user should put a regex where he matches everything but the generic page he want's to scan.

```
docker run -it soosio/dast ... --excludeUrlsFile="exclude_urls.txt"
```
Where `exclude_urls.txt` contents are:

``` exclude_urls.txt
^https://app\.soos\.io/research/vulnerabilities/(?!CVE-2015-8048/|CVE-2015-8047/).+$
^https://app\.soos\.io/research/repositories/(?!github/soos-io/soos-ci-analysis-python/).+$
^https://app\.soos\.io/research/licenses/(?!0BSD/|AAL/).+$
^https://app\.soos\.io/research/packages/[^/]+/(?!@soos-io/soos-sbom/|@soos-io/soos-sca/).+$
^https://app\.soos\.io/research/license-exceptions/(?!vsftpd-openssl-exception).+$
```

<!---
If you've edited any of the arguments for this package:

1. Run this script with the --helpFormatted argument (ex. soos-dast --helpFormatted)
2. Copy the result and paste it in the README under '### Script Arguments'
3. Make sure your terminal didn't wrap any lines, confirm the table looks correct
-->
